### PR TITLE
Fix path to mfcc_hires.conf

### DIFF
--- a/kaldiasr/nnet3.pyx
+++ b/kaldiasr/nnet3.pyx
@@ -67,7 +67,7 @@ cdef class KaldiNNet3OnlineModel:
         self.modeldir         = modeldir
         self.model            = model
 
-        cdef string mfcc_config           = '%s/conf/mfcc-hires.conf'   % self.modeldir
+        cdef string mfcc_config           = '%s/conf/mfcc_hires.conf'   % self.modeldir
         cdef string word_symbol_table     = '%s/%s/words.txt'           % (self.modeldir, self.model)
         cdef string model_in_filename     = '%s/%s/final.mdl'           % (self.modeldir, self.model)
         cdef string splice_conf_filename  = '%s/extractor/splice.conf'  % self.modeldir


### PR DESCRIPTION
The script [speech_kaldi_export.py](https://github.com/gooofy/zamia-speech/blob/27073ebc5ef06c0e3989623fd5de1903d11ad6b3/speech_kaldi_export.py#L408) writes the file `conf/mfcc_hires.mfcc`, i.e. with an underscore as a word seperator instead of a hyphen.